### PR TITLE
Fix: Remove trailing dot from URL map host_rule hostname

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   default_service   = var.bucket_name != null ? google_compute_backend_bucket.backend_bucket[0].self_link : google_compute_backend_service.backend_service[0].id
-  hostnames           = var.hostnames != null ? var.hostnames : [google_dns_record_set.dns_record_set.name]
   path_matcher_name = "pm-${var.environment}-${var.project_name}"
 }
 
@@ -35,7 +34,7 @@ resource "google_compute_managed_ssl_certificate" "ssl_certificate" {
   name     = "cert-${var.environment}-${var.project_name}"
   project  = var.project
   managed {
-    domains = local.hostnames
+    domains = var.hostnames != null ? var.hostnames : [google_dns_record_set.dns_record_set.name]
   }
 }
 
@@ -49,7 +48,7 @@ resource "google_compute_url_map" "url_map" {
   dynamic "host_rule" {
     for_each = length(var.url_rewrite_rules) > 0 ? [1] : []
     content {
-      hosts        = local.hostnames
+      hosts        = var.hostnames != null ? var.hostnames : [var.dns_name]
       path_matcher = local.path_matcher_name
     }
   }


### PR DESCRIPTION
The `host_rule.hosts` field performs exact matches against the hostname portion of incoming requests. A trailing dot alters the hostname, potentially causing mismatches.

Screenshot taken from the Terraform plan executed for this [draft PR.](https://github.com/admatch/web-app/pull/68)![image](https://github.com/user-attachments/assets/b5622f3e-725c-48f9-a460-9d3428528585)


This PR removes the trailing dot (.) from the `host_rule.hosts` value in the URL map configuration. `[google_dns_record_set.dns_record_set.name]` replaced with `[var.dns_name]`

